### PR TITLE
fix: blow up when `GetOrdersResponse#orders` is called with errors in body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Extract errors from response body
 
+### FIxed
+- No longer blow up when `GetOrdersResponse#orders` is called but body has errors
+
 ## [0.1.0] - 2020-09-12
 ### Added
 - add `get_orders` endpoint

--- a/lib/okcoin_client/responses/get_orders_response.rb
+++ b/lib/okcoin_client/responses/get_orders_response.rb
@@ -8,6 +8,8 @@ module OkcoinClient
     private
 
     def default_success
+      return false if error_message.present?
+
       unless parsed_body.present?
         return false
       end
@@ -23,6 +25,8 @@ module OkcoinClient
     end
 
     def default_orders
+      return [] if not self.success?
+
       parsed_body.map do |order_hash|
         Order.new(order_hash)
       end

--- a/spec/okcoin_client/responses/get_orders_response_spec.rb
+++ b/spec/okcoin_client/responses/get_orders_response_spec.rb
@@ -23,6 +23,26 @@ module OkcoinClient
           expect(empty_response).not_to be_success
         end
       end
+
+      context "errors exist" do
+        let(:response) { described_class.new(error_message: "something") }
+        subject { response.success }
+
+        it { is_expected.to be false }
+      end
+    end
+
+    describe "#orders" do
+      context "parsed body contains errors" do
+        let(:response) { described_class.new(parsed_body: parsed_body) }
+        let(:parsed_body) do
+          [ ["error_message", "The currency pair does not exist"] ]
+        end
+
+        it "is empty" do
+          expect(response.orders).to be_empty
+        end
+      end
     end
 
   end


### PR DESCRIPTION
Check that the response is successful, and if not, return an empty array for orders